### PR TITLE
Fix routing

### DIFF
--- a/docs/dev/rest.md
+++ b/docs/dev/rest.md
@@ -44,7 +44,24 @@ On instantiation, the api class also registers all available maps, and parses th
 #### 4.1 Router
 Prior to calling `Router`, the api class gathers all maps. Maps are received from two places:
 
-1. module.xml's as cached in FreePBX's database. These are received via the `modulelist` class and stored in `$this->mods`
+1. module.xml's as cached in FreePBX's database. These are received via the `modulelist` class and stored in `$this->mods`. An example of adding a map to module.xml is below:
+ ```
+ <apimap>
+    <get>
+        <path>
+            <url>/myawesomeendpoint</url>
+            <path>class.mycontroller.php</path>
+            <controller>restapi_MyControllerClassName</controller>
+            <module>myfreepbxmodule</module>
+            <method>get</method>
+            <target>
+                <controller_path>class.mycontroller.php</controller_path>
+            </target>
+        </path>
+    </get>
+</apimap>
+```
+
 2. maps.php of modules folded in to the restapi module. These maps are NOT cached, and are parsed at every instantiation. The file tree is as follows:
 
 ```

--- a/functions.inc/api.class.php
+++ b/functions.inc/api.class.php
@@ -130,8 +130,8 @@ class Api{
 			}
 
 			foreach ($details['apimap'] as $verb => $maps) {
-				foreach ($maps as $url => $map) {
-					$this->add_map($verb, $url, $mod, $map);
+				foreach ($maps as $path => $map) {
+					$this->add_map($verb, $map['url'], $mod, $map);
 				}
 			}
 		}

--- a/functions.inc/api.class.php
+++ b/functions.inc/api.class.php
@@ -131,9 +131,20 @@ class Api{
 
 			foreach ($details['apimap'] as $verb => $maps) {
 				foreach ($maps as $path => $map) {
-					$this->add_map($verb, $map['url'], $mod, $map);
+					if($this->isAssoc($map)) {
+						$this->add_map($verb, $map['url'], $mod, $map);
+						continue;
+					}
+					foreach($map as $endpoints => $maps) {
+						$this->add_map($verb, $maps['url'], $mod, $maps);
+					}
 				}
 			}
+			
+			
+			
+			
+			
 		}
 
 		unset($details);
@@ -851,6 +862,14 @@ class Api{
 			$this->log->event('Response', $this->res);
 		}
 		return true;
+	}
+	
+	/**
+	 * Checks if array is associative or not
+	 */
+	function isAssoc(array $arr) {
+		if(array() === $arr) return false;
+		return array_keys($arr) !== range(0, count($arr) - 1);
 	}
 }
 ?>


### PR DESCRIPTION
By making this change you can easily add the XML below to any module.xml and have REST endpoints automatically created. The old method of doing this didn't seem to work or allow multiple routes to be added.

```
<apimap>
	<post>
		<endpoint>
			<url>/photos</url>
			<path>class.photoController.php</path>
			<controller>restapi_PhotoController</controller>
			<module>myCustomModule</module>
			<method>store</method>
			<target>
				<controller>class.photoController.php</controller>
			</target>
		</endpoint>
	</post>
	<get>
		<endpoint>
			<url>/alpinehomeair/:id</url>
			<path>class.photoController.php</path>
			<controller>restapi_PhotoController</controller>
			<module>myCustomModule</module>
			<method>create</method>
			<target>
				<controller>class.photoController.php</controller>
			</target>
		</endpoint>
		<endpoint>
			<url>/alpinehomeair</url>
			<path>class.photoController.php</path>
			<controller>restapi_PhotoController</controller>
			<module>myCustomModule</module>
			<method>index</method>
			<target>
				<controller>class.photoController.php</controller>
			</target>
		</endpoint>
	</get>
</apimap>
```